### PR TITLE
Fix torch to numpy conversion

### DIFF
--- a/gymnasium/wrappers/numpy_to_torch.py
+++ b/gymnasium/wrappers/numpy_to_torch.py
@@ -36,10 +36,15 @@ def torch_to_numpy(value: Any) -> Any:
 
 
 @torch_to_numpy.register(numbers.Number)
-@torch_to_numpy.register(torch.Tensor)
-def _number_torch_to_numpy(value: numbers.Number | torch.Tensor) -> Any:
-    """Convert a python number (int, float, complex) and torch.Tensor to a numpy array."""
+def _number_to_numpy(value: numbers.Number) -> Any:
+    """Convert a python number (int, float, complex) to a numpy array."""
     return np.array(value)
+
+
+@torch_to_numpy.register(torch.Tensor)
+def _torch_to_numpy(value: torch.Tensor) -> Any:
+    """Convert a torch.Tensor to a numpy array."""
+    return value.numpy(force=True)
 
 
 @torch_to_numpy.register(abc.Mapping)


### PR DESCRIPTION
# Description

A small fix to properly convert `torch.Tenor` into `numpy.ndarray`. As mentioned, converting from `torch` to `jax` does not cause the same error, at least when `jax[cuda]` is installed.

Fixes #1108

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
